### PR TITLE
Made an avenue to offset the snapshot index from CTrees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,16 @@
+## These are code optimization options
 #OPT += -DUSE_FGETS
 #OPT += -USE_MPI
 OPT += -DUSE_STRINGPARSE
+
+
+# This is to correct the snapshot index output by
+# Consistent Trees into the actual simulation snapshot
+# number. See https://bitbucket.org/pbehroozi/consistent-trees/commits/41866601a537ce5f3d159d0364ef7d7082da43a5
+# For instance, if the first 5 snapshots in the simulation
+# did not contain sufficient halos, then the Consistent Trees `snap_idx == 0`
+# will correspond to the simulation `snapnum == 5`
+OPT += -DSNAP_OFFSET=0
 
 include common.mk
 

--- a/convert_trees_to_lhalo.c
+++ b/convert_trees_to_lhalo.c
@@ -615,13 +615,10 @@ int64_t read_tree_into_forest(int64_t *nhalos_allocated, struct output_dtype **s
             forest[nhalos].NextProgenitor = -1;
             forest[nhalos].FirstHaloInFOFgroup = -1;
             forest[nhalos].NextHaloInFOFgroup = -1;
-            /* if(info[nhalos].id == 3058982278 || info[nhalos].id == 3058982280) { */
-            /*     fprintf(stderr,"info[%"PRId64"].id = %"PRId64". pid = %"PRId64" upid = %"PRId64"\n", */
-            /*             nhalos, info[nhalos].id, info[nhalos].pid, info[nhalos].upid); */
-            /*     fprintf(stderr,"##buffer = `%s'###\n",&buffer[start_pos]); */
-            /*     fprintf(stderr,"M200 = %lf Mtophat = %lf\n", forest[nhalos].M_Mean200, forest[nhalos].M_TopHat); */
-            /* } */
             
+            /* Convert the snapshot index output by Consistent Trees
+               into the snapshot number as reported by the simulation */
+            forest[nhalos].SnapNum += SNAP_OFFSET;
 
 #if 0
             if(num_lines_printed < 10000) {


### PR DESCRIPTION
The snapshot index output by CTrees need to be shifted occasionally to match the original simulation snapshot numbers. 

(See the `snap_num` to `snap_idx` change on the Consistent Trees [repo commit](https://bitbucket.org/pbehroozi/consistent-trees/commits/41866601a537ce5f3d159d0364ef7d7082da43a5))